### PR TITLE
Fix wrong use of PluginControllerInterface as API class

### DIFF
--- a/src/Payum/Bridge/JMSPayment/Action/AuthorizeAction.php
+++ b/src/Payum/Bridge/JMSPayment/Action/AuthorizeAction.php
@@ -4,6 +4,7 @@ namespace Payum\Bridge\JMSPayment\Action;
 use JMS\Payment\CoreBundle\Model\PaymentInterface;
 use JMS\Payment\CoreBundle\Plugin\Exception\Action\VisitUrl;
 use JMS\Payment\CoreBundle\Plugin\Exception\ActionRequiredException;
+use JMS\Payment\CoreBundle\PluginController\EntityPluginController;
 use JMS\Payment\CoreBundle\PluginController\PluginControllerInterface;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\ApiAwareInterface;
@@ -22,7 +23,7 @@ class AuthorizeAction implements ActionInterface, ApiAwareInterface
     
     public function __construct()
     {
-        $this->apiClass = PluginControllerInterface::class;
+        $this->apiClass = EntityPluginController::class;
     }
 
     /**


### PR DESCRIPTION
In actions, API classes cannot be interfaces as Payum checks API class validity with `class_exists()`
(see `ApiAwareTrait`).

Instead, use `EntityPluginController::class` like in `CaptureAction`.
